### PR TITLE
Support Android Firefox (Fenix)

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -107,7 +107,12 @@ function handlePromptMessage({ id, condition, host, level }, sender) {
   }
 
   delete prompts[id];
-  browser.windows.remove(sender.tab.windowId);
+  if (browser.windows) {
+    browser.windows.remove(sender.tab.windowId);
+  } else {
+    // Android Firefox
+    browser.tabs.remove(sender.tab.id);
+  }
 }
 
 function promptPermission(host, level, params) {
@@ -120,12 +125,21 @@ function promptPermission(host, level, params) {
   });
 
   return new Promise((resolve, reject) => {
-    browser.windows.create({
-      url: `${browser.runtime.getURL('prompt.html')}?${qs.toString()}`,
-      type: 'popup',
-      width: 600,
-      height: 400
-    });
+    const url = `${browser.runtime.getURL('prompt.html')}?${qs.toString()}`;
+    if (browser.windows) {
+      browser.windows.create({
+        url,
+        type: 'popup',
+        width: 600,
+        height: 400
+      });
+    } else {
+      // Android Firefox
+      browser.tabs.create({
+        url,
+        active: true
+      });
+    }
 
     prompts[id] = { resolve, reject };
   });

--- a/src/options.html
+++ b/src/options.html
@@ -2,6 +2,7 @@
 <html lang="en" style="width: 100%; height: 100%;">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>nos2x-fox</title>
 
     <link rel="stylesheet" href="style.css" />

--- a/src/popup.html
+++ b/src/popup.html
@@ -3,6 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>nos2x-fox</title>
     <link rel="stylesheet" href="style.css" />
   </head>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -56,6 +56,8 @@ function Popup() {
     browser.tabs.create({
       url: browser.runtime.getURL('options.html'),
       active: true
+    }).then(() => {
+      window.close();
     });
   }
 

--- a/src/prompt.html
+++ b/src/prompt.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>nos2x-fox</title>
     <link rel="stylesheet" href="style.css" />
   </head>


### PR DESCRIPTION
You can use this method to install nos2x-fox on Android Firefox Nightly:
https://blog.mozilla.org/addons/2020/09/29/expanded-extension-support-in-firefox-for-android-nightly/

For testing on Android:
https://extensionworkshop.com/documentation/develop/developing-extensions-for-firefox-for-android/

There is no `browser.windows` in Android Firefox, so we have to fallback to `browser.tabs`.

Closes #8

EDIT: Added commit for usability on Android

<details><summary>Screenshots</summary>

![20230214_023800](https://user-images.githubusercontent.com/65112898/218529796-6ae67902-7f37-4679-be70-82860ed75126.png)
![20230214_022801](https://user-images.githubusercontent.com/65112898/218529822-40b297f6-c442-4430-9fa0-d690f24c07b0.png)

</details>
