### PR TITLE
Fix inability to save private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![](src/assets/logo/logotype.png)
-# nos2x-fox (nos2x for Forefox)
+
+# nos2x-fox (nos2x for Firefox)
+
 notes and other stuff signed by an extension
 
 This is a fork from https://github.com/fiatjaf/nos2x focused on Firefox and related browsers.
@@ -20,8 +22,8 @@ async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext
 
 ## Install
 
-* By yourself from file: look into [Releases](https://github.com/diegogurpegui/nos2x-fox/releases)
-* From the site [Firefox Add-on](https://addons.mozilla.org/en-US/firefox/addon/nos2x-fox/)
+- By yourself from file: look into [Releases](https://github.com/diegogurpegui/nos2x-fox/releases)
+- From the site [Firefox Add-on](https://addons.mozilla.org/en-US/firefox/addon/nos2x-fox/)
 
 ## Develop
 
@@ -35,12 +37,12 @@ $ yarn run build
 ```
 
 After you build the extension, follow these steps:
+
 1. Open Firefox
 2. Go to about:debugging
 3. Click on "This Firefox" on the left
 4. Click on "Load Temporary Add-on..."
 5. Select any file from the `dist/` folder of the extension
-
 
 ## Screenshots
 

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -190,13 +190,11 @@ function Options() {
 
     let hexOrEmptyPrivKey = privateKey;
 
-    if (!isHexadecimal(privateKey)) {
-      try {
-        let { type, data } = nip19.decode(privateKey);
-        if (type === 'nsec') hexOrEmptyPrivKey = data;
-      } catch (err) {
-        console.error('Converting key to hexa (decode NIP19)', err);
-      }
+    try {
+      let { type, data } = nip19.decode(privateKey);
+      if (type === 'nsec') hexOrEmptyPrivKey = data;
+    } catch (err) {
+      console.error('Converting key to hexa (decode NIP19)', err);
     }
 
     if (hexOrEmptyPrivKey !== '') {
@@ -226,8 +224,9 @@ function Options() {
     if (privateKey.match(/^[a-f0-9]{64}$/)) return true;
     try {
       if (nip19.decode(privateKey).type === 'nsec') return true;
-    } catch (_) {}
-    console.log('bad');
+    } catch (e) {
+      console.error(`Error decoding NIP19 key: ${e}`);
+    }
     return false;
   }
 


### PR DESCRIPTION
When starting the extension up for the first time in the options page, it is currently impossible to save a private key. I received the following error in the console:

```
Uncaught (in promise) Error: private key must be 32 bytes, hex or bigint, not string
    normPrivateKeyToScalar moz-extension://243e3cba-6882-4214-8ce3-87ff39dc7e8b/options.js:25675
    schnorrGetExtPubKey moz-extension://243e3cba-6882-4214-8ce3-87ff39dc7e8b/options.js:26512
    schnorrGetPublicKey moz-extension://243e3cba-6882-4214-8ce3-87ff39dc7e8b/options.js:26533
    getPublicKey moz-extension://243e3cba-6882-4214-8ce3-87ff39dc7e8b/options.js:31647
    updateActivePrivateKey moz-extension://243e3cba-6882-4214-8ce3-87ff39dc7e8b/options.js:34723
    savePrivateKey moz-extension://243e3cba-6882-4214-8ce3-87ff39dc7e8b/options.js:34996
```

It turned out the error was due to a recently added `!isHexadecimal` check failing, which results in the `hexOrEmptyPrivKey` variable having the `nsec` encoded version, which causes a cascading issue with `nostr-tools` `getPublicKey` function. The solution was to remove this non-functioning `!isHexadecimal` check, which doesn't appear to be necessary anyway since the check is being done with:

```
      let { type, data } = nip19.decode(privateKey);
      if (type === 'nsec') hexOrEmptyPrivKey = data;
```