### PR TITLE
Reject event on prompt close

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -17,7 +17,7 @@ browser.runtime.onMessage.addListener((message, sender) => {
   let { prompt } = message;
 
   if (prompt) {
-    return handlePromptMessage(message, sender);
+    handlePromptMessage(message, sender);
   } else {
     return handleContentScriptMessage(message);
   }
@@ -29,6 +29,14 @@ browser.runtime.onMessageExternal.addListener(
     handleContentScriptMessage({ type, params, host: extensionId });
   }
 );
+
+browser.windows.onRemoved.addListener(_windowId => {
+  if (openPrompt) {
+    // calling this with a simple "no" response will not store anything, so it's fine
+    // it will just return a failure
+    handlePromptMessage({accept: false}, null)
+  }
+})
 
 async function handleContentScriptMessage({ type, params, host }) {
   let level = await readPermissionLevel(host);


### PR DESCRIPTION
Closes #30 

Closing the prompt window rejects events, copied directly from the nos2x extension. Here is fiatjaf's commit on it https://github.com/fiatjaf/nos2x/commit/6938503893d79ed7d4a941713e9884377ea0bd2e

I don't think there should be any changed logic seing as its for firefox vs chrome but I'm not 100% sure, I have tested this though and it works!