### PR TITLE
Implement getPublicKeyIfApproved() call for better UX.

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -43,20 +43,28 @@ browser.windows.onRemoved.addListener(_windowId => {
 async function handleContentScriptMessage({ type, params, host }) {
   let level = await readPermissionLevel(host);
 
-  if (level >= PERMISSIONS_REQUIRED[type]) {
+  // getPublicKeyIfApproved doesn't need a separate permission, use getPublicKey.
+  let permName = type.replace('IfApproved', '')
+
+  if (level >= PERMISSIONS_REQUIRED[permName]) {
     // authorized, proceed
   } else {
+    if (type === 'getPublicKeyIfApproved') {
+      // Pubkey not authorized.
+      return ""
+    }
+
     // ask for authorization
     try {
       const isAllowed = await promptPermission(
         host,
-        PERMISSIONS_REQUIRED[type],
+        PERMISSIONS_REQUIRED[permName],
         params
       );
       if (!isAllowed) {
         // not authorized, stop here
         return {
-          error: `Insufficient permissions, required ${PERMISSIONS_REQUIRED[type]}`
+          error: `Insufficient permissions, required ${PERMISSIONS_REQUIRED[permName]}`
         };
       }
     } catch (error) {
@@ -75,6 +83,7 @@ async function handleContentScriptMessage({ type, params, host }) {
 
   try {
     switch (type) {
+      case 'getPublicKeyIfApproved':
       case 'getPublicKey': {
         return getPublicKey(sk);
       }

--- a/src/nostr-provider.ts
+++ b/src/nostr-provider.ts
@@ -5,6 +5,12 @@ window.nostr = {
   _requests: {},
   _pubkey: null,
 
+  async getPublicKeyIfApproved() {
+    if (this._pubkey || this._pubkey === '') return this._pubkey;
+    this._pubkey = await this._call('getPublicKeyIfApproved', {});
+    return this._pubkey;
+  },
+
   async getPublicKey() {
     if (this._pubkey) return this._pubkey;
     this._pubkey = await this._call('getPublicKey', {});


### PR DESCRIPTION
Background here: https://github.com/nostr-protocol/nips/pull/1599

The main idea is to simplify login logic in the client. The client doesn't need to store the pubkey in localstorage, it can query the extension for the currently used pubkey.

It also allows for the client to detect any changes in the extension (using a different profile, revoking permission, etc) With the localstorage solution it is ususally detected too late, when the user wants to sign an event, but the pubkeys don't match.