### PR TITLE
Migrate to Manifest V3 with activeTab

### DIFF
--- a/src/hosted/manifest.json
+++ b/src/hosted/manifest.json
@@ -9,7 +9,7 @@
       "update_url": "https://diegogurpegui.com/nos2x-fox/updates.json"
     }
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "icons": {
     "16": "assets/logo/16x16.png",
     "32": "assets/logo/32x32.png",
@@ -18,13 +18,12 @@
     "128": "assets/logo/128x128.png"
   },
   "options_ui": {
-    "page": "options.html",
-    "browser_style": true
+    "page": "options.html"
   },
   "background": {
     "scripts": ["background.js"]
   },
-  "browser_action": {
+  "action": {
     "default_title": "nos2x-fox",
     "default_popup": "popup.html"
   },
@@ -35,7 +34,14 @@
       "js": ["content-script.js"]
     }
   ],
-  "permissions": ["storage"],
-  "web_accessible_resources": ["nostr-provider.js"],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"
+  "permissions": ["storage", "activeTab"],
+  "web_accessible_resources": [
+    {
+      "resources": ["nostr-provider.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'"
+  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,7 @@
       "id": "{fdacee2c-bab4-490d-bc4b-ecdd03d5d68a}"
     }
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "icons": {
     "16": "assets/logo/16x16.png",
     "32": "assets/logo/32x32.png",
@@ -17,13 +17,12 @@
     "128": "assets/logo/128x128.png"
   },
   "options_ui": {
-    "page": "options.html",
-    "browser_style": true
+    "page": "options.html"
   },
   "background": {
     "scripts": ["background.js"]
   },
-  "browser_action": {
+  "action": {
     "default_title": "nos2x-fox",
     "default_popup": "popup.html"
   },
@@ -34,7 +33,14 @@
       "js": ["content-script.js"]
     }
   ],
-  "permissions": ["storage"],
-  "web_accessible_resources": ["nostr-provider.js"],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"
+  "permissions": ["storage", "activeTab"],
+  "web_accessible_resources": [
+    {
+      "resources": ["nostr-provider.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'"
+  }
 }


### PR DESCRIPTION
I simply wanted to add in `activeTab` to selectively run the extension on certain sites I use Nostr on. Apparently this only works with Manifest V3. Not experienced with JS, so not sure if this might cause issues I am not aware of, but the console logs look fine when I was debugging it.

EDIT: Thinking more on this it could lead to compatibility issues. Tempted to close this out. Or feedback on how to provide both v2 and v3 manifests.